### PR TITLE
Add CLOUDFLARE_PUSH_EXTENSIONS setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,18 @@ Settings
 --------
 
 ```python
-CLOUDFLARE_PUSH_EXTENSIONS = ['css', 'js', '*']
+CLOUDFLARE_PUSH_FILTER = lambda file: True
 ```
 
-Allows you to customize the order and extensions that will be pushed to the
-client. The default setting prioritizes CSS and JavaScript by default. You
-can omit `'*'` to make this setting act as a whitelist for extensions. For
-instance, to push _only_ CSS and JavaScript files:
+Allows you to customize what files will be sent to the client to be preloaded.
+This setting should be set to a callable, which accepts a single parameter
+(the name of the file to preload). By default, `django-cloudflare-push` pushes
+all static files.
+
+For instance, to push _only_ static CSS and JavaScript files:
 
 ```python
-CLOUDFLARE_PUSH_EXTENSIONS = ['css', 'js']
+CLOUDFLARE_PUSH_FILTER = lambda x: x.endswith('.css') or x.endswith('.js')
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ MIDDLEWARE = (
 Done! Your static media will be pushed. You can test the middleware by looking
 for the `Link` header.
 
+Settings
+--------
+
+```python
+CLOUDFLARE_PUSH_EXTENSIONS = ['css', 'js', '*']
+```
+
+Allows you to customize the order and extensions that will be pushed to the
+client. The default setting prioritizes CSS and JavaScript by default. You
+can omit `'*'` to make this setting act as a whitelist for extensions. For
+instance, to push _only_ CSS and JavaScript files:
+
+```python
+CLOUDFLARE_PUSH_EXTENSIONS = ['css', 'js']
+```
 
 License
 -------


### PR DESCRIPTION
Thanks for this awesome middleware! I plan to use this on a future project.

However, there is one issue with this middleware. I use the Django static file system to store certain assets that don't change (social media images for Facebook and Twitter, for instance), and I'd like to not those pushed to the client (since they don't have much use for those anyway).

This adds a setting (`CLOUDFLARE_PUSH_EXTENSIONS`), which allows customizing whether or not to push certain file extensions to the client, and to specify which order you want.