### PR TITLE
Fix module not found on django ver. >= 3

### DIFF
--- a/django_cloudflare_push/middleware.py
+++ b/django_cloudflare_push/middleware.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     # django.contrib.staticfiles.templatetags.staticfiles removed in django 3.0
     # https://github.com/django/django/blob/a6b3938afc0204093b5356ade2be30b461a698c5/docs/releases/3.0.txt#L661
-    pass
+    from django.contrib.staticfiles import storage as staticfiles
 from django.core.files.storage import get_storage_class
 from django.utils.functional import LazyObject
 
@@ -85,7 +85,7 @@ def create_header_content(urls):
 def push_middleware(get_response):
     def middleware(request):
         collector = FileCollector()
-        storage.staticfiles_storage = storage_factory(collector)()
+        storage.staticfiles_storage = staticfiles.staticfiles_storage = storage_factory(collector)()
         response = get_response(request)
         collection_copy = list(collector.collection)  # For compatibility with 2.7.
         urls = list(set(storage.staticfiles_storage.url(f) for f in collection_copy))

--- a/django_cloudflare_push/middleware.py
+++ b/django_cloudflare_push/middleware.py
@@ -2,7 +2,6 @@
 
 from django.conf import settings
 from django.contrib.staticfiles import storage
-from django.contrib.staticfiles.templatetags import staticfiles
 from django.core.files.storage import get_storage_class
 from django.utils.functional import LazyObject
 
@@ -80,7 +79,7 @@ def create_header_content(urls):
 def push_middleware(get_response):
     def middleware(request):
         collector = FileCollector()
-        storage.staticfiles_storage = staticfiles.staticfiles_storage = storage_factory(collector)()
+        storage.staticfiles_storage = storage_factory(collector)()
         response = get_response(request)
         collection_copy = list(collector.collection)  # For compatibility with 2.7.
         urls = list(set(storage.staticfiles_storage.url(f) for f in collection_copy))

--- a/django_cloudflare_push/middleware.py
+++ b/django_cloudflare_push/middleware.py
@@ -2,6 +2,12 @@
 
 from django.conf import settings
 from django.contrib.staticfiles import storage
+try:
+    from django.contrib.staticfiles.templatetags import staticfiles
+except ImportError:
+    # django.contrib.staticfiles.templatetags.staticfiles removed in django 3.0
+    # https://github.com/django/django/blob/a6b3938afc0204093b5356ade2be30b461a698c5/docs/releases/3.0.txt#L661
+    pass
 from django.core.files.storage import get_storage_class
 from django.utils.functional import LazyObject
 


### PR DESCRIPTION
Regarding issue #7 and compatibility with django version 3 and up.

Looks like the last django release that used the `templatetags` module was version 1.9.  I think you did that double assignment in order to allow a method in that module to still work.  Here's what that module looked like at that time:

https://github.com/django/django/blob/stable/1.9.x/django/contrib/staticfiles/templatetags/staticfiles.py#L8-L9

I'm wondering, now that the module is gone, and people are hopefully running on something newer than 1.9, whether it makes sense to continue to support that version?  If not, the fix is simple, and it's to just remove that assignment and import statement.  Works for ver. 3 and 2.2 and should work for 1.10 and above, I think.

If the desire is to support 1.9 still, well, I'm not entirely sure how to do that in the cleanest way.  Possibly simplest to just namespace the new module with the old name?

Something like: 

`from django.contrib.staticfiles import storage as staticfiles`

Then the code in the actual middleware code stays the same.  This is what I've done currently PR.

I think probably preferable to avoid any conditional inside the middleware if possible?