### PR TITLE
Also include files with extension webp to be pushed

### DIFF
--- a/django_cloudflare_push/middleware.py
+++ b/django_cloudflare_push/middleware.py
@@ -20,6 +20,7 @@ EXTENSION_AS = {
     'jpeg': 'image',
     'svg': 'image',
     'gif': 'image',
+    'webp': 'image',
     'ttf': 'font',
     'woff': 'font',
     'woff2': 'font'


### PR DESCRIPTION
If you take a look at the waterfall in chrome developer, you'll notice webp files are still initiated from the page, and not pushed.
This fixes it, by including the extension in the extension list, this list is later used to select files for forwarding.